### PR TITLE
Update jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -82,12 +82,11 @@ jobs:
             then
               filePath=${files[0]##*.\\/}
             else
-              filePath="${filePath}
-              ${files[i]##*.\\/}"
+              filePath="${filePath}\n${files[i]##*.\\/}"
             fi
           done
           echo "filePath="${filePath}
-          echo "file="${filePath} >> $GITHUB_OUTPUT
+          echo -e "file="${filePath} >> $GITHUB_OUTPUT
       - name: commit
         id: commit
         uses: yui-Kitamura/commit@2.0.1


### PR DESCRIPTION
改行
bash(on Linux)で`\n`をechoするのは -e オプションが必要